### PR TITLE
Removed apply plugin and added the plugin for protobuf gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,9 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.12'
-    }
-}
-
 plugins {
     id 'org.springframework.boot' version '2.4.2'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id 'com.google.protobuf' version '0.8.12'
 }
-
-apply plugin: 'com.google.protobuf'
 
 group = 'io.adven.grpc.wiremock'
 version = '0.0.1-SNAPSHOT'


### PR DESCRIPTION
apply plugin need not be used and is considered old. Defining the plugins to be used in the 'plugin' block is the newer way.