### PR TITLE
Fix java.lang.OutOfMemoryError: Java heap space.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir -p /proto
 RUN touch /proto/any.proto
 ENV GRADLE_USER_HOME /home/gradle/cache_home
 COPY build.gradle /home/gradle/java-code/
+COPY gradle.properties /home/gradle/java-code/
 WORKDIR /home/gradle/java-code
 RUN gradle build -i --no-daemon || return 0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
### What
When I use this repo with a relatively big number of `.proto` files I was getting `java.lang.OutOfMemoryError: Java heap space` error during `compileJava` task:
```
> Task :compileJava
Excluding []
Caching disabled for task ':compileJava' because:
  Build cache is disabled
Task ':compileJava' is not up-to-date because:
  No history is available.
The input changes require a full rebuild for incremental task ':compileJava'.
Full recompilation is required because no incremental change information is available. This is usually caused by clean builds or changing compiler arguments.
Compiling with JDK Java compiler API.
compiler message file broken: key=compiler.misc.msg.bug arguments=11.0.7, {1}, {2}, {3}, {4}, {5}, {6}, {7}
java.lang.OutOfMemoryError: Java heap space
        at jdk.compiler/com.sun.tools.javac.util.Position$LineMapImpl.build(Position.java:156)
        at jdk.compiler/com.sun.tools.javac.util.Position.makeLineMap(Position.java:80)

```

One of the solutions to it is to add `gradle.properties` file in repo root with `org.gradle.jvmargs=-Xmx4096m` which fixed the problem for me:
```
# `-Xmx4096m` was added:
Starting process 'Gradle build daemon'. Working directory: /home/gradle/.gradle/daemon/6.4.1 Command: /opt/java/openjdk/bin/java --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.prefs/java.util.prefs=ALL-UNNAMED -Xmx4096m -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant -cp /opt/gradle/lib/gradle-launcher-6.4.1.jar org.gradle.launcher.daemon.bootstrap.GradleDaemon 6.4.1
Successfully started process 'Gradle build daemon'
An attempt to start the daemon took 1.101 secs.
The client will now receive all logging from the daemon (pid: 43). The daemon log file: /home/gradle/.gradle/daemon/6.4.1/daemon-43.out.log
Starting build in new daemon [memory: 4.3 GB]
Using 8 worker leases.
```

