### PR TITLE
Fix java.io.IOException: Too many open files

### DIFF
--- a/src/main/java/io/adven/grpc/wiremock/HttpMock.java
+++ b/src/main/java/io/adven/grpc/wiremock/HttpMock.java
@@ -28,6 +28,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 public class HttpMock {
     private static final Logger LOG = LoggerFactory.getLogger(HttpMock.class);
     private final WireMockServer server;
+    private final HttpClient httpClient;
 
     public HttpMock(WiremockProperties properties) {
         WireMockConfiguration config = wireMockConfig()
@@ -43,6 +44,7 @@ public class HttpMock {
             config.disableRequestJournal();
         }
         server = new WireMockServer(config);
+        httpClient = HttpClient.newHttpClient();
     }
 
     @PostConstruct
@@ -61,7 +63,7 @@ public class HttpMock {
 
     private HttpResponse<String> request(String path, Object message) throws IOException, InterruptedException {
         LOG.info("Grpc request {}:\n{}", path, message);
-        final HttpResponse<String> response = HttpClient.newHttpClient().send(
+        final HttpResponse<String> response = httpClient.send(
             HttpRequest.newBuilder().uri(URI.create(server.baseUrl() + "/" + path)).POST(asJson(message)).build(),
             HttpResponse.BodyHandlers.ofString()
         );


### PR DESCRIPTION
I was running into this error frequently:
```
java.lang.InternalError: java.io.IOException: Too many open files
	at java.net.http/jdk.internal.net.http.HttpClientImpl.<init>(HttpClientImpl.java:311)
	at java.net.http/jdk.internal.net.http.HttpClientImpl.create(HttpClientImpl.java:253)
	at java.net.http/jdk.internal.net.http.HttpClientBuilderImpl.build(HttpClientBuilderImpl.java:135)
	at java.net.http/java.net.http.HttpClient.newHttpClient(HttpClient.java:158)
	at io.adven.grpc.wiremock.HttpMock.request(HttpMock.java:64)
	at io.adven.grpc.wiremock.HttpMock.send(HttpMock.java:59)
	at ...
```
this PR is one way to fix it & is what fixed the problem for me -- switching to using a single `HttpClient` instance rather than creating a new one for each request. 