### PR TITLE
Upgrade wiremock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation "io.grpc:grpc-all:${grpcVersion}"
     implementation 'org.xerial.snappy:snappy-java:1.1.8.4'
-    implementation 'com.github.tomakehurst:wiremock-standalone:2.27.2'
+    implementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.30.1'
 }
 
 protobuf {


### PR DESCRIPTION
The Java 7 version is deprecated, so Switch to the Java 8+ build.

We had problems with verification failing despite requesting the order of arrays being ignored, and this was rectified by switching Wiremock from 2.72.2 to 2.30.1.