### PR TITLE
Prune service classes before processing them

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,14 @@ task generateJava(type: Copy) {
             println "Parsed package = [$pkg], serviceName = [$serviceName] and fullServiceName = [$fullServiceName]"
 
             def text = file.text
+
+            // Even though the file name looked like a grpc service class, dont process it
+            // if you dont find a reference to an abstract class.
+            if (text.indexOf('public static abstract class') == -1) {
+                println "Skipping processing $file.path because its not a Service class."
+                return
+            }
+
             def rpcMethodAnnotation = "@io.grpc.stub.annotations.RpcMethod("
             Map<String, String> respTypes = new HashMap<>()
             Map<String, String> methodTypes = new HashMap<>()


### PR DESCRIPTION
Closes #27

Some messages may contain message names that 
end up looking like a service class because of its
name.

Fixed this by also checking if the file content 
has an abstract class (which is a more reliable way
of ascertaining if a class is a service class or not)

Now if we use the same proto file as mentioned in the issue, the output would look like below

```bash

➜  grpc-wiremock git:(fix_issue_27) ✗ ./gradlew clean generateJava

> Task :generateJava
Found com/rationaleemotions/HelloWorldGrpc.java: 
Parsed package = [com.rationaleemotions], serviceName = [HelloWorld] and fullServiceName = [ComRationaleemotionsHelloWorld]
Found com/rationaleemotions/InputGrpc.java: 
Parsed package = [com.rationaleemotions], serviceName = [Input] and fullServiceName = [ComRationaleemotionsInput]
Skipping processing /Users/krmahadevan/githome/oss/grpc-wiremock/src/main/java/com/rationaleemotions/InputGrpc.java because its not a Service class.
Found com/rationaleemotions/OutputGrpc.java: 
Parsed package = [com.rationaleemotions], serviceName = [Output] and fullServiceName = [ComRationaleemotionsOutput]
Skipping processing /Users/krmahadevan/githome/oss/grpc-wiremock/src/main/java/com/rationaleemotions/OutputGrpc.java because its not a Service class.

BUILD SUCCESSFUL in 5s
5 actionable tasks: 5 executed

```