### PR TITLE
update docker actions and add arm64 image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,17 +9,29 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            adven27/grpc-wiremock
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push tag
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: adven27/grpc-wiremock
-          tag_with_ref: true
-      - name: Push latest
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: adven27/grpc-wiremock
-          tags: latest
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'release' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,5 @@
 name: Publish Docker image
 on:
-  push:
-    branches: [arm64]
   release:
     types: [published]
 jobs:
@@ -16,9 +14,8 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            jstewmon/grpc-wiremock
+            adven27/grpc-wiremock
           tags: |
-            type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
       - name: Set up QEMU

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Publish Docker image
 on:
+  push:
+    branches: [arm64]
   release:
     types: [published]
 jobs:
@@ -14,8 +16,9 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            adven27/grpc-wiremock
+            jstewmon/grpc-wiremock
           tags: |
+            type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
       - name: Set up QEMU


### PR DESCRIPTION
I used the intermediate commits to test this on my local branch. I didn't rebase them out to "show my work" in the PR, but I'm happy to rebase them out if you like.

Here's the action run from my fork:
https://github.com/jstewmon/grpc-wiremock/actions/runs/2235639897

Here's the resulting docker image tag on Docker Hub:
https://hub.docker.com/layers/grpc-wiremock/jstewmon/grpc-wiremock/arm64/images/sha256-41202879efb285cce147179157f5bf1bc87da3f88b371f2c5bbe3f4772ccb965?context=explore

In addition to producing both amd64 and arm64 images, I added a `major.minor` image tag.

closes #34 